### PR TITLE
Better handling of Scale NFS, better determining of Scale version for comparison

### DIFF
--- a/plugins/module_utils/setup.py
+++ b/plugins/module_utils/setup.py
@@ -27,7 +27,7 @@ def get_tn_version():
     try:
         # product_name is a string like "TrueNAS".
         # product_type is a string like "CORE".
-        # product_version is a string like "TrueNAS-13.0-U5"
+        # product_version is a string like "TrueNAS-13.0-U5", or "TrueNAS-SCALE-22.12.3.1"
         product_name = mw.call("system.product_name", output='str')
         product_type = mw.call("system.product_type", output='str')
         sys_version = mw.call("system.version", output='str')
@@ -38,6 +38,10 @@ def get_tn_version():
     # leaving just the version number.
     if sys_version.startswith(f"{product_name}-"):
         sys_version = sys_version[len(product_name)+1:]
+
+    # Strip "SCALE-" from the beginning of the version string if it exists.
+    if sys_version.startswith(f"{product_type}-"):
+        sys_version = sys_version[len(product_type)+1:]
 
     sys_version = version.parse(sys_version)
 

--- a/plugins/modules/sharing_nfs.py
+++ b/plugins/modules/sharing_nfs.py
@@ -640,8 +640,12 @@ def nfs2():
             # Make list of differences between what is and what should
             # be.
             arg = {}
-            if name is not None and export_info['comment'] != name:
-                arg['comment'] = name
+            try:
+                if name is not None and export_info['name'] != name:
+                    arg['name'] = name
+            except KeyError as error:
+                if name is not None and export_info['comment'] != name:
+                    arg['comment'] = name
 
             if alldirs is not None and export_info['alldirs'] != alldirs:
                 arg['alldirs'] = alldirs

--- a/plugins/modules/sharing_nfs.py
+++ b/plugins/modules/sharing_nfs.py
@@ -640,9 +640,8 @@ def nfs2():
             # Make list of differences between what is and what should
             # be.
             arg = {}
-
-            if name is not None and export_info['name'] != name:
-                arg['name'] = name
+            if name is not None and export_info['comment'] != name:
+                arg['comment'] = name
 
             if alldirs is not None and export_info['alldirs'] != alldirs:
                 arg['alldirs'] = alldirs


### PR DESCRIPTION
There are two changes as part of this PR:

The first is to update how the version of Truenas is determined. The product format between Scale and Core is different in that system.version returns `<product_name>-<product_version>` for Core, but `<product_name>-<product_type>-<product_version>` for Scale (e.g. `TrueNAS-13.0-U5` vs `TrueNAS-SCALE-22.12.3.1`) meaning that the way the version is currently determined/compared results in the version string not being correctly extracted. This change will strip system.product_type (if it exists) from the leading edge of the sys_version variable before extracting the product version.

The second change is that querying existing NFS shares in Scale returns key:values where the comment **is** the name. 
Example query output:
`{'id': 2, 'path': '/mnt/zvol/test', 'aliases': [], 'comment': 'test', 'hosts': [], 'ro': False, 'quiet': False, 'maproot_user': 'root', 'maproot_group': 'wheel', 'mapall_user': None, 'mapall_group': None, 'security': [], 'enabled': True, 'networks': ['172.16.0.0/24'], 'locked': False}\n`

This results in a KeyError exception since the `name` key cannot be found in the `export_info` object, only `comment`. I've wrapped the existing functionality in a try/except, that falls back to taking the `comment` of the share to compare to the proposed `name` of the NFS share to be updated. This works for me, but there may be a better/cleaner way to do the same thing? 🤷‍♂️