### PR TITLE
quick fix for middleware job typo

### DIFF
--- a/plugins/module_utils/midclt.py
+++ b/plugins/module_utils/midclt.py
@@ -153,7 +153,7 @@ class Midclt:
 
         try:
             err = Midclt.call(func,
-                              opts=["-job", "-jp", "description"],
+                              opts=["--job", "-jp", "description"],
                               output='str',
                               *args, **kwargs)
 


### PR DESCRIPTION
The `mw.job` was throwing an error because `midclt` was being called with `-job`, so it parsed as `-j ob`. The correct calling method used double dashes.