### PR TITLE
support sharing_nfs in TrueNAS Community Edition 25.04

### DIFF
--- a/plugins/modules/sharing_nfs.py
+++ b/plugins/modules/sharing_nfs.py
@@ -763,7 +763,7 @@ def main():
     # parameter from 'paths' to 'path'.
     TC_22_12_2 = version.parse("22.12.2")
     if tn_version['name'] == "TrueNAS" and \
-       tn_version['type'] == "SCALE" and \
+       (tn_version['type'] == "SCALE" or tn_version['type'] == "COMMUNITY_EDITION") and \
        tn_version['version'] >= TC_22_12_2:
         return nfs2()
     else:

--- a/plugins/modules/sharing_nfs.py
+++ b/plugins/modules/sharing_nfs.py
@@ -763,7 +763,7 @@ def main():
     # parameter from 'paths' to 'path'.
     TC_22_12_2 = version.parse("22.12.2")
     if tn_version['name'] == "TrueNAS" and \
-       (tn_version['type'] == "SCALE" or tn_version['type'] == "COMMUNITY_EDITION") and \
+       tn_version['type'] in ["SCALE", "COMMUNITY_EDITION", "ENTERPRISE"] and \
        tn_version['version'] >= TC_22_12_2:
         return nfs2()
     else:


### PR DESCRIPTION
A small change I had to make to get NFS exports to work properly in 25.04, which has type COMMUNITY_EDITION instead of SCALE.

Previously, due to the change in "version type", the older NFS1 code would be selected, resulting in this error message:
```
Error creating NFS export \"None\": midclt exited with status 1: \"[EINVAL] data.path: Field required\n[EINVAL] data.comment: Input should be a valid string\n[EINVAL] data.paths: Extra inputs are not permitted\n\"
```
Now, TrueNAS version 25.04 uses `nfs2()` instead which works great.