### PR TITLE
(Bug fix) NFS Share creation broken on TrueNAS Scale 25.04

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -58,6 +58,16 @@ releases:
     fragments:
     - midclt.yaml
     release_date: '2025-06-11'
+  1.11.6:
+    changes:
+      bugfixes:
+      - paths is no longer present in sharing.nfs.query results for 
+        TrueNAS Scale versions newer than 25.04. A check has been added to omit
+        it from the payload in this scenario to maintain compatibility.
+      release_summary: Bug fix.
+    fragments:
+    - sharing_nfs.yaml
+    release_date: '2025-06-26'
   1.4.5:
     changes:
       breaking_changes:

--- a/plugins/modules/sharing_nfs.py
+++ b/plugins/modules/sharing_nfs.py
@@ -435,13 +435,13 @@ class NFS1:
 
                 # Check whether the path is the same as the old.
                 # We use set comparison because the order doesn't matter.
-                if set(paths) != set(export_info['paths']):
+                if 'paths' in export_info and set(paths) != set(export_info['paths']):
                     arg['paths'] = paths
 
                 # Check whether the new set of networks is the same as the
                 # old set.
                 if networks is not None and \
-                   set(networks) != set(export_info['networks']):
+                   set(networks) != set(export_info.get('networks', [])):
                     arg['networks'] = networks
 
                 # Check whether the new set of hosts is the same as the

--- a/plugins/modules/sharing_nfs.py
+++ b/plugins/modules/sharing_nfs.py
@@ -441,7 +441,7 @@ class NFS1:
                 # Check whether the new set of networks is the same as the
                 # old set.
                 if networks is not None and \
-                   set(networks) != set(export_info.get('networks', [])):
+                   set(networks) != set(export_info['networks']):
                     arg['networks'] = networks
 
                 # Check whether the new set of hosts is the same as the


### PR DESCRIPTION
After upgrading my local installation to Scale 25.04, I found my Ansible scripts started erroring out on creation of NFS Shares. 

Upon investigation, it looks like the paths array has been removed from the JSON response for sharing.nfs.query, which causes the Ansible module to error out with an index-not-found exception. 

This change omits paths from the request payload sent to midclt if it's not been provided in the response.