### PR TITLE
Fix(group): Handle non_unique parameter based on TrueNAS version

### DIFF
--- a/plugins/modules/group.py
+++ b/plugins/modules/group.py
@@ -33,7 +33,7 @@ options:
     description:
       - Allow a non-unique I(GID) for the group.
       - If I(non_unique) is true, a I(GID) must be specified.
-      - This is ignored starting with I(SCALE 24.10)
+      - This is ignored starting with I(SCALE 25.04)
     type: bool
     default: no
 seealso:


### PR DESCRIPTION
I started using the module in ansible against truenas scale version 25.04 and encountered failures when creating groups. The root cause of the failure was the presence of  *allow_duplicate_gid* in the group.create call. Looking through the
documentation this appears to have become unsupported with version 24.10 with an explicit note in the documentation stating as such.

This commit modifies the  module to ignore the non_unique parameter when used with truenas scale versions >= 24.10