### PR TITLE
SMB Should only be True if omitted on creation - not updates

### DIFF
--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -336,7 +336,7 @@ def main():
             # XXX - remove: delete home directory. builtin.user allows
             # doing this.
 
-            smb=dict(type='bool', default=True),
+            smb=dict(type='bool', default=None),
 
             sudo_commands=dict(type='list',
                                elements='str'),
@@ -536,6 +536,8 @@ def main():
 
             if smb is not None:
                 arg['smb'] = smb
+            else:
+                arg['smb'] = True
 
             if old_sudo_call:
                 # 'old_sudo_call' isn't set to True until we know that


### PR DESCRIPTION
Right now if you omit smb it is set to true - In that case if you update a user where smb is False, it will then try to change it to true.

```yaml
- name: "[TrueNAS] Ensure user \"root\" exists"
  arensb.truenas.user:
    name: root
    ssh_authorized_keys:
      - "{{ rootuser_pub_key }}"
```