### PR TITLE
Fix password handling bug in user.py. Syntax/Typo ':' to '='

### DIFF
--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -521,7 +521,7 @@ def main():
                 # specified. So let's make sure that a password is
                 # wanted, first.
                 if not password_disabled:
-                    arg['password']: password
+                    arg['password'] = password
 
             if comment is None:
                 arg['full_name'] = ""


### PR DESCRIPTION
There was a small type that seemed to prevent users with passwords enabled from being created.  It was always saying password is required, because it wasn't getting set properly.

I believe this fixes Issue #49 (Error when creating user)
