### PR TITLE
Add support for iSCSI shares

### DIFF
--- a/changelogs/fragments/iscsi.yaml
+++ b/changelogs/fragments/iscsi.yaml
@@ -1,0 +1,7 @@
+major_changes:
+  - >
+    Added iSCSI sharing support across seven new modules: ``iscsi`` (global
+    service config), ``iscsi_portal``, ``iscsi_initiator``, ``iscsi_auth``,
+    ``iscsi_extent``, ``iscsi_target``, and ``iscsi_targetextent``. Together
+    these cover the full TrueNAS iSCSI configuration surface; the existing
+    ``service`` module handles starting/stopping the ``iscsitarget`` daemon.

--- a/plugins/modules/iscsi.py
+++ b/plugins/modules/iscsi.py
@@ -33,8 +33,9 @@ options:
     type: int
   pool_avail_threshold:
     description:
-      - Pool free-space alert threshold, as a percentage. Set to C(0) to
-        disable.
+      - Pool free-space alert threshold, as a percentage. Valid range is
+        C(1) to C(99). Omit the parameter to leave the value alone; the
+        TrueNAS API does not accept C(0) here.
     type: int
   alua:
     description:

--- a/plugins/modules/iscsi.py
+++ b/plugins/modules/iscsi.py
@@ -1,0 +1,157 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+__metaclass__ = type
+
+# Configure the iSCSI service (global settings).
+
+DOCUMENTATION = '''
+---
+module: iscsi
+short_description: Configure iSCSI service
+description:
+  - Configure global parameters of the iSCSI (target) service.
+  - For individual portals, initiator groups, authorized accesses, extents,
+    targets, and target/extent associations, see the C(iscsi_portal),
+    C(iscsi_initiator), C(iscsi_auth), C(iscsi_extent), C(iscsi_target),
+    and C(iscsi_targetextent) modules.
+options:
+  basename:
+    description:
+      - Base part of the iSCSI Qualified Name (IQN).
+      - Combined with the target name to form the full IQN advertised by
+        the server. Should follow C(iqn.YYYY-MM.<reverse-domain>) form.
+    type: str
+  isns_servers:
+    description:
+      - List of iSNS server addresses to register with.
+    type: list
+    elements: str
+  listen_port:
+    description:
+      - TCP port that the iSCSI target listens on.
+      - Default is C(3260).
+    type: int
+  pool_avail_threshold:
+    description:
+      - Pool free-space alert threshold, as a percentage. Set to C(0) to
+        disable.
+    type: int
+  alua:
+    description:
+      - Enable Asymmetric Logical Unit Access. Only meaningful on TrueNAS HA
+        systems.
+    type: bool
+version_added: 1.15.0
+'''
+
+EXAMPLES = '''
+- name: Set the iSCSI base name
+  hosts: truenas
+  become: yes
+  tasks:
+    - arensb.truenas.iscsi:
+        basename: iqn.2005-10.org.example.ctl
+
+- name: Use a non-default port and register with iSNS
+  hosts: truenas
+  become: yes
+  tasks:
+    - arensb.truenas.iscsi:
+        listen_port: 3261
+        isns_servers:
+          - 10.0.0.5
+
+- name: Make sure the iSCSI service is enabled and running
+  hosts: truenas
+  become: yes
+  tasks:
+    - arensb.truenas.iscsi:
+        basename: iqn.2005-10.org.example.ctl
+    - arensb.truenas.service:
+        name: iscsitarget
+        state: started
+        enabled: yes
+'''
+
+RETURN = '''
+status:
+  description:
+    - A dict describing the current state of the iSCSI global configuration.
+    - In check_mode and when no changes are needed, this is the current
+      state. After a successful update, this is the new state.
+  type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ..module_utils.middleware import MiddleWare as MW
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            basename=dict(type='str'),
+            isns_servers=dict(type='list', elements='str'),
+            listen_port=dict(type='int'),
+            pool_avail_threshold=dict(type='int'),
+            alua=dict(type='bool'),
+        ),
+        supports_check_mode=True,
+    )
+
+    result = dict(
+        changed=False,
+        msg=''
+    )
+
+    mw = MW.client()
+
+    basename = module.params['basename']
+    isns_servers = module.params['isns_servers']
+    listen_port = module.params['listen_port']
+    pool_avail_threshold = module.params['pool_avail_threshold']
+    alua = module.params['alua']
+
+    try:
+        info = mw.call("iscsi.global.config")
+    except Exception as e:
+        module.fail_json(msg=f"Error looking up iSCSI global configuration: {e}")
+
+    result['status'] = info
+
+    arg = {}
+
+    if basename is not None and info.get('basename') != basename:
+        arg['basename'] = basename
+
+    if isns_servers is not None and \
+       set(isns_servers) != set(info.get('isns_servers') or []):
+        arg['isns_servers'] = isns_servers
+
+    if listen_port is not None and info.get('listen_port') != listen_port:
+        arg['listen_port'] = listen_port
+
+    if pool_avail_threshold is not None and \
+       info.get('pool_avail_threshold') != pool_avail_threshold:
+        arg['pool_avail_threshold'] = pool_avail_threshold
+
+    if alua is not None and info.get('alua') is not alua:
+        arg['alua'] = alua
+
+    if len(arg) == 0:
+        result['changed'] = False
+    else:
+        if module.check_mode:
+            result['msg'] = f"Would have updated iscsi global config: {arg}"
+        else:
+            try:
+                err = mw.call("iscsi.global.update", arg)
+                result['status'] = err
+            except Exception as e:
+                module.fail_json(msg=f"Error updating iscsi global config with {arg}: {e}")
+        result['changed'] = True
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/iscsi.py
+++ b/plugins/modules/iscsi.py
@@ -30,6 +30,10 @@ options:
     description:
       - TCP port that the iSCSI target listens on.
       - Default is C(3260).
+      - Only available on TrueNAS SCALE / Community Edition (added in
+        SCALE 22.12). On TrueNAS CORE the listen port is configured
+        per-portal via the C(iscsi_portal) module instead. The value
+        is ignored with a warning when running against CORE.
     type: int
   pool_avail_threshold:
     description:
@@ -85,6 +89,7 @@ status:
 
 from ansible.module_utils.basic import AnsibleModule
 from ..module_utils.middleware import MiddleWare as MW
+from ..module_utils.setup import get_tn_version
 
 
 def main():
@@ -113,6 +118,13 @@ def main():
     alua = module.params['alua']
 
     try:
+        tn_version = get_tn_version()
+    except Exception as e:
+        module.fail_json(msg=f"Error getting TrueNAS version: {e}")
+
+    is_core = tn_version['type'] == 'CORE'
+
+    try:
         info = mw.call("iscsi.global.config")
     except Exception as e:
         module.fail_json(msg=f"Error looking up iSCSI global configuration: {e}")
@@ -128,8 +140,13 @@ def main():
        set(isns_servers) != set(info.get('isns_servers') or []):
         arg['isns_servers'] = isns_servers
 
-    if listen_port is not None and info.get('listen_port') != listen_port:
-        arg['listen_port'] = listen_port
+    if listen_port is not None:
+        if is_core:
+            module.warn("listen_port is ignored on TrueNAS CORE; "
+                        "configure the listen port per-portal via the "
+                        "iscsi_portal module instead.")
+        elif info.get('listen_port') != listen_port:
+            arg['listen_port'] = listen_port
 
     if pool_avail_threshold is not None and \
        info.get('pool_avail_threshold') != pool_avail_threshold:

--- a/plugins/modules/iscsi.py
+++ b/plugins/modules/iscsi.py
@@ -152,7 +152,7 @@ def main():
        info.get('pool_avail_threshold') != pool_avail_threshold:
         arg['pool_avail_threshold'] = pool_avail_threshold
 
-    if alua is not None and info.get('alua') is not alua:
+    if alua is not None and info.get('alua') != alua:
         arg['alua'] = alua
 
     if len(arg) == 0:

--- a/plugins/modules/iscsi_auth.py
+++ b/plugins/modules/iscsi_auth.py
@@ -1,0 +1,208 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+__metaclass__ = type
+
+# Manage iSCSI authorized accesses (CHAP entries).
+
+DOCUMENTATION = '''
+---
+module: iscsi_auth
+short_description: Manage iSCSI authorized accesses (CHAP credentials)
+description:
+  - Create, modify, and delete iSCSI authorized accesses.
+  - Each entry holds a CHAP user/secret (and optionally a mutual CHAP
+    peer user/secret), and is grouped by an integer C(tag). Multiple
+    entries can share a tag; portals and targets reference the tag,
+    not the row C(id).
+  - The combination of C(tag) and C(user) uniquely identifies a row.
+options:
+  tag:
+    description:
+      - Group tag this entry belongs to. Portals and targets reference
+        the tag.
+    type: int
+    required: true
+  user:
+    description:
+      - CHAP username.
+    type: str
+    required: true
+  secret:
+    description:
+      - CHAP secret. The TrueNAS middleware enforces a length of 12 to
+        16 characters.
+      - Required when creating a new entry. When updating, the secret is
+        only changed if you explicitly supply this option (the existing
+        secret cannot be read back, so it is impossible to know whether
+        a change is needed - supplying it always counts as a change).
+    type: str
+    no_log: true
+  peeruser:
+    description:
+      - Mutual-CHAP peer username. Empty disables mutual CHAP.
+    type: str
+  peersecret:
+    description:
+      - Mutual-CHAP peer secret. Same length constraints as C(secret).
+      - Always counts as a change when supplied (cannot be read back).
+    type: str
+    no_log: true
+  state:
+    description:
+      - Whether the entry should exist or not.
+    type: str
+    choices: [ absent, present ]
+    default: present
+version_added: 1.15.0
+'''
+
+EXAMPLES = '''
+- name: Create a CHAP entry in group 1
+  arensb.truenas.iscsi_auth:
+    tag: 1
+    user: client1
+    secret: somesecret1234
+
+- name: Add a mutual CHAP entry in group 2
+  arensb.truenas.iscsi_auth:
+    tag: 2
+    user: client2
+    secret: secret123456
+    peeruser: server
+    peersecret: peersecret12
+
+- name: Remove a CHAP entry
+  arensb.truenas.iscsi_auth:
+    tag: 1
+    user: client1
+    state: absent
+'''
+
+RETURN = '''
+auth:
+  description:
+    - A dict describing the CHAP entry after the operation.
+    - The C(secret) field is excluded from the return value.
+  type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ..module_utils.middleware import MiddleWare as MW
+
+
+def _scrub(row):
+    """Strip secret fields before returning the row to the user."""
+    if not row:
+        return row
+    out = dict(row)
+    out.pop('secret', None)
+    out.pop('peersecret', None)
+    return out
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            tag=dict(type='int', required=True),
+            user=dict(type='str', required=True),
+            secret=dict(type='str', no_log=True),
+            peeruser=dict(type='str'),
+            peersecret=dict(type='str', no_log=True),
+            state=dict(type='str', default='present',
+                       choices=['absent', 'present']),
+        ),
+        supports_check_mode=True,
+    )
+
+    result = dict(
+        changed=False,
+        msg=''
+    )
+
+    mw = MW.client()
+
+    tag = module.params['tag']
+    user = module.params['user']
+    secret = module.params['secret']
+    peeruser = module.params['peeruser']
+    peersecret = module.params['peersecret']
+    state = module.params['state']
+
+    try:
+        rows = mw.call("iscsi.auth.query",
+                       [["tag", "=", tag], ["user", "=", user]])
+        row = rows[0] if rows else None
+    except Exception as e:
+        module.fail_json(msg=f"Error looking up iscsi auth (tag={tag}, user={user}): {e}")
+
+    if row is None:
+        if state == 'present':
+            if secret is None:
+                module.fail_json(
+                    msg=f"Cannot create iscsi auth (tag={tag}, user={user}): 'secret' is required")
+
+            arg = {
+                "tag": tag,
+                "user": user,
+                "secret": secret,
+            }
+            if peeruser is not None:
+                arg['peeruser'] = peeruser
+            if peersecret is not None:
+                arg['peersecret'] = peersecret
+
+            if module.check_mode:
+                result['msg'] = f"Would have created iscsi auth (tag={tag}, user={user})"
+            else:
+                try:
+                    err = mw.call("iscsi.auth.create", arg)
+                    result['auth'] = _scrub(err)
+                except Exception as e:
+                    module.fail_json(msg=f"Error creating iscsi auth (tag={tag}, user={user}): {e}")
+            result['changed'] = True
+        else:
+            result['changed'] = False
+    else:
+        if state == 'present':
+            arg = {}
+
+            if peeruser is not None and row.get('peeruser') != peeruser:
+                arg['peeruser'] = peeruser
+
+            # Secrets cannot be read back; if the user supplied one,
+            # treat it as a requested change.
+            if secret is not None:
+                arg['secret'] = secret
+            if peersecret is not None:
+                arg['peersecret'] = peersecret
+
+            if len(arg) == 0:
+                result['changed'] = False
+                result['auth'] = _scrub(row)
+            else:
+                if module.check_mode:
+                    redacted = {k: ('<set>' if k in ('secret', 'peersecret') else v)
+                                for k, v in arg.items()}
+                    result['msg'] = f"Would have updated iscsi auth (tag={tag}, user={user}): {redacted}"
+                else:
+                    try:
+                        err = mw.call("iscsi.auth.update", row['id'], arg)
+                        result['auth'] = _scrub(err)
+                    except Exception as e:
+                        module.fail_json(msg=f"Error updating iscsi auth (tag={tag}, user={user}): {e}")
+                result['changed'] = True
+        else:
+            if module.check_mode:
+                result['msg'] = f"Would have deleted iscsi auth (tag={tag}, user={user})"
+            else:
+                try:
+                    mw.call("iscsi.auth.delete", row['id'])
+                except Exception as e:
+                    module.fail_json(msg=f"Error deleting iscsi auth (tag={tag}, user={user}): {e}")
+            result['changed'] = True
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/iscsi_auth.py
+++ b/plugins/modules/iscsi_auth.py
@@ -156,8 +156,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=f"Error getting TrueNAS version: {e}")
 
-    is_scale_or_ce = tn_version['type'] in {"SCALE", "COMMUNITY_EDITION",
-                                            "ENTERPRISE"}
+    is_scale_or_ce = tn_version['type'] in {"SCALE", "COMMUNITY_EDITION"}
     has_discovery_auth = is_scale_or_ce and tn_version['version'] >= TC_25_04
 
     if discovery_auth is not None and not has_discovery_auth:

--- a/plugins/modules/iscsi_auth.py
+++ b/plugins/modules/iscsi_auth.py
@@ -47,6 +47,18 @@ options:
       - Always counts as a change when supplied (cannot be read back).
     type: str
     no_log: true
+  discovery_auth:
+    description:
+      - Authentication method to require for discovery-phase logins
+        when this entry is referenced as the discovery auth group.
+      - Available on TrueNAS SCALE 25.04 (Fangtooth) and later, where
+        the C(discovery_authmethod) and C(discovery_authgroup) fields
+        on C(iscsi.portal) were retired in favor of this field. On
+        earlier versions configure discovery auth via the
+        C(iscsi_portal) module instead; passing C(discovery_auth) on
+        an older host produces a warning and is otherwise ignored.
+    type: str
+    choices: [ NONE, CHAP, CHAP_MUTUAL ]
   state:
     description:
       - Whether the entry should exist or not.
@@ -87,7 +99,15 @@ auth:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
+from packaging import version
 from ..module_utils.middleware import MiddleWare as MW
+from ..module_utils.setup import get_tn_version
+
+
+# discovery_auth was added to iscsi.auth in TrueNAS SCALE 25.04
+# (Fangtooth), replacing the per-portal discovery_authmethod/group
+# fields.
+TC_25_04 = version.parse("25.04")
 
 
 def _scrub(row):
@@ -108,6 +128,8 @@ def main():
             secret=dict(type='str', no_log=True),
             peeruser=dict(type='str'),
             peersecret=dict(type='str', no_log=True),
+            discovery_auth=dict(type='str',
+                                choices=['NONE', 'CHAP', 'CHAP_MUTUAL']),
             state=dict(type='str', default='present',
                        choices=['absent', 'present']),
         ),
@@ -126,7 +148,25 @@ def main():
     secret = module.params['secret']
     peeruser = module.params['peeruser']
     peersecret = module.params['peersecret']
+    discovery_auth = module.params['discovery_auth']
     state = module.params['state']
+
+    try:
+        tn_version = get_tn_version()
+    except Exception as e:
+        module.fail_json(msg=f"Error getting TrueNAS version: {e}")
+
+    is_scale_or_ce = tn_version['type'] in {"SCALE", "COMMUNITY_EDITION",
+                                            "ENTERPRISE"}
+    has_discovery_auth = is_scale_or_ce and tn_version['version'] >= TC_25_04
+
+    if discovery_auth is not None and not has_discovery_auth:
+        module.warn("discovery_auth requires TrueNAS SCALE 25.04 or "
+                    "later; on older versions configure discovery auth "
+                    "via iscsi_portal's discovery_authmethod/"
+                    "discovery_authgroup options. The supplied value "
+                    "is ignored.")
+        discovery_auth = None
 
     try:
         rows = mw.call("iscsi.auth.query",
@@ -150,6 +190,8 @@ def main():
                 arg['peeruser'] = peeruser
             if peersecret is not None:
                 arg['peersecret'] = peersecret
+            if discovery_auth is not None:
+                arg['discovery_auth'] = discovery_auth
 
             if module.check_mode:
                 result['msg'] = f"Would have created iscsi auth (tag={tag}, user={user})"
@@ -168,6 +210,10 @@ def main():
 
             if peeruser is not None and row.get('peeruser') != peeruser:
                 arg['peeruser'] = peeruser
+
+            if discovery_auth is not None and \
+               row.get('discovery_auth') != discovery_auth:
+                arg['discovery_auth'] = discovery_auth
 
             # Secrets cannot be read back; if the user supplied one,
             # treat it as a requested change.

--- a/plugins/modules/iscsi_extent.py
+++ b/plugins/modules/iscsi_extent.py
@@ -54,8 +54,9 @@ options:
     type: bool
   avail_threshold:
     description:
-      - Per-extent free-space alert threshold (percentage). Set to C(0)
-        or null to disable.
+      - Per-extent free-space alert threshold (percentage). Valid range
+        is C(1) to C(99). Omit the parameter to leave the value alone;
+        the TrueNAS API does not accept C(0) here.
     type: int
   comment:
     description:
@@ -256,7 +257,16 @@ def main():
                     continue
                 if k in _SERVER_MANAGED:
                     continue
-                if extent.get(k) != v:
+                current = extent.get(k)
+                # TrueNAS 25.04+ stores filesize as a string. Cast both
+                # sides to int so we don't report a spurious change every
+                # run.
+                if k == 'filesize':
+                    try:
+                        current = int(current) if current is not None else current
+                    except (TypeError, ValueError):
+                        pass
+                if current != v:
                     arg[k] = v
 
             if len(arg) == 0:

--- a/plugins/modules/iscsi_extent.py
+++ b/plugins/modules/iscsi_extent.py
@@ -1,0 +1,292 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+__metaclass__ = type
+
+# Manage iSCSI extents.
+
+DOCUMENTATION = '''
+---
+module: iscsi_extent
+short_description: Manage iSCSI extents
+description:
+  - Create, modify, and delete iSCSI extents.
+  - An extent is the storage backing a LUN. It can be a ZFS zvol
+    (C(type=DISK)) or a regular file (C(type=FILE)).
+  - The dataset/zvol or directory must already exist; this module does
+    not create them. Use the C(filesystem) module to manage zvols.
+options:
+  name:
+    description:
+      - Name of the extent. Used as the unique identifier.
+    type: str
+    required: true
+  type:
+    description:
+      - Type of backing store.
+      - C(DISK) (default) backs the extent with a ZFS zvol.
+      - C(FILE) backs the extent with a regular file on a dataset.
+    type: str
+    choices: [ DISK, FILE ]
+  disk:
+    description:
+      - Path of the backing zvol relative to C(/dev), in the form
+        C(zvol/<pool>/<dataset>). Required when C(type=DISK).
+    type: str
+  path:
+    description:
+      - Path of the backing file. Required when C(type=FILE).
+    type: str
+  filesize:
+    description:
+      - Size of the backing file in bytes. Must be a multiple of
+        C(blocksize). Required and must be non-zero when
+        C(type=FILE). Use C(0) for a DISK extent to consume the whole
+        zvol.
+    type: int
+  blocksize:
+    description:
+      - Logical block size reported to initiators. Default C(512).
+    type: int
+    choices: [ 512, 1024, 2048, 4096 ]
+  pblocksize:
+    description:
+      - If true, also report the physical block size.
+    type: bool
+  avail_threshold:
+    description:
+      - Per-extent free-space alert threshold (percentage). Set to C(0)
+        or null to disable.
+    type: int
+  comment:
+    description:
+      - Free-form description.
+    type: str
+  insecure_tpc:
+    description:
+      - Allow third-party copy (XCOPY/VAAI) without authentication.
+    type: bool
+  xen:
+    description:
+      - Enable Xen initiator compatibility mode.
+    type: bool
+  rpm:
+    description:
+      - Reported rotation rate. Strings, even for the numeric values.
+    type: str
+    choices: [ UNKNOWN, SSD, '5400', '7200', '10000', '15000' ]
+  ro:
+    description:
+      - Make the extent read-only.
+    type: bool
+  enabled:
+    description:
+      - If false, the extent exists but is not advertised.
+    type: bool
+  serial:
+    description:
+      - Unique serial advertised to initiators. If unset, the
+        middleware autogenerates one.
+    type: str
+  delete_file:
+    description:
+      - When deleting a C(FILE) extent, also remove the backing file
+        from disk. Has no effect for C(DISK) extents.
+    type: bool
+    default: false
+  force:
+    description:
+      - When deleting, bypass safety checks for active sessions.
+    type: bool
+    default: false
+  state:
+    description:
+      - Whether the extent should exist or not.
+    type: str
+    choices: [ absent, present ]
+    default: present
+version_added: 1.15.0
+'''
+
+EXAMPLES = '''
+- name: Zvol-backed extent
+  arensb.truenas.iscsi_extent:
+    name: lun0
+    type: DISK
+    disk: zvol/tank/iscsi/lun0
+
+- name: File-backed extent
+  arensb.truenas.iscsi_extent:
+    name: lun-file
+    type: FILE
+    path: /mnt/tank/iscsi/lun-file.img
+    filesize: 10737418240
+
+- name: Read-only extent with custom block size
+  arensb.truenas.iscsi_extent:
+    name: lun-readonly
+    type: DISK
+    disk: zvol/tank/iscsi/ro
+    blocksize: 4096
+    ro: true
+
+- name: Delete a FILE extent and remove the backing file
+  arensb.truenas.iscsi_extent:
+    name: lun-file
+    state: absent
+    delete_file: true
+'''
+
+RETURN = '''
+extent:
+  description:
+    - A dict describing the extent after the operation.
+  type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ..module_utils.middleware import MiddleWare as MW
+
+
+# Fields the middleware computes/manages and we should not diff against.
+_SERVER_MANAGED = {'naa', 'vendor', 'product_id', 'locked', 'id'}
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(type='str', required=True),
+            type=dict(type='str', choices=['DISK', 'FILE']),
+            disk=dict(type='str'),
+            path=dict(type='str'),
+            filesize=dict(type='int'),
+            blocksize=dict(type='int', choices=[512, 1024, 2048, 4096]),
+            pblocksize=dict(type='bool'),
+            avail_threshold=dict(type='int'),
+            comment=dict(type='str'),
+            insecure_tpc=dict(type='bool'),
+            xen=dict(type='bool'),
+            rpm=dict(type='str',
+                     choices=['UNKNOWN', 'SSD',
+                              '5400', '7200', '10000', '15000']),
+            ro=dict(type='bool'),
+            enabled=dict(type='bool'),
+            serial=dict(type='str'),
+            delete_file=dict(type='bool', default=False),
+            force=dict(type='bool', default=False),
+            state=dict(type='str', default='present',
+                       choices=['absent', 'present']),
+        ),
+        mutually_exclusive=[
+            ['disk', 'path'],
+        ],
+        supports_check_mode=True,
+    )
+
+    result = dict(
+        changed=False,
+        msg=''
+    )
+
+    mw = MW.client()
+
+    name = module.params['name']
+    state = module.params['state']
+    delete_file = module.params['delete_file']
+    force = module.params['force']
+
+    # Diffable input parameters mapped to API field names.
+    inputs = {
+        'type': module.params['type'],
+        'disk': module.params['disk'],
+        'path': module.params['path'],
+        'filesize': module.params['filesize'],
+        'blocksize': module.params['blocksize'],
+        'pblocksize': module.params['pblocksize'],
+        'avail_threshold': module.params['avail_threshold'],
+        'comment': module.params['comment'],
+        'insecure_tpc': module.params['insecure_tpc'],
+        'xen': module.params['xen'],
+        'rpm': module.params['rpm'],
+        'ro': module.params['ro'],
+        'enabled': module.params['enabled'],
+        'serial': module.params['serial'],
+    }
+
+    try:
+        rows = mw.call("iscsi.extent.query",
+                       [["name", "=", name]])
+        extent = rows[0] if rows else None
+    except Exception as e:
+        module.fail_json(msg=f"Error looking up extent {name}: {e}")
+
+    if extent is None:
+        if state == 'present':
+            extent_type = inputs['type'] or 'DISK'
+            if extent_type == 'DISK' and not inputs['disk']:
+                module.fail_json(msg=f"Cannot create DISK extent {name}: 'disk' is required")
+            if extent_type == 'FILE':
+                if not inputs['path']:
+                    module.fail_json(msg=f"Cannot create FILE extent {name}: 'path' is required")
+                if not inputs['filesize']:
+                    module.fail_json(msg=f"Cannot create FILE extent {name}: 'filesize' is required")
+
+            arg = {"name": name}
+            for k, v in inputs.items():
+                if v is not None:
+                    arg[k] = v
+
+            if module.check_mode:
+                result['msg'] = f"Would have created extent {name} with {arg}"
+            else:
+                try:
+                    err = mw.call("iscsi.extent.create", arg)
+                    result['extent'] = err
+                except Exception as e:
+                    result['failed_invocation'] = arg
+                    module.fail_json(msg=f"Error creating extent {name}: {e}")
+            result['changed'] = True
+        else:
+            result['changed'] = False
+    else:
+        if state == 'present':
+            arg = {}
+
+            for k, v in inputs.items():
+                if v is None:
+                    continue
+                if k in _SERVER_MANAGED:
+                    continue
+                if extent.get(k) != v:
+                    arg[k] = v
+
+            if len(arg) == 0:
+                result['changed'] = False
+                result['extent'] = extent
+            else:
+                if module.check_mode:
+                    result['msg'] = f"Would have updated extent {name}: {arg}"
+                else:
+                    try:
+                        err = mw.call("iscsi.extent.update",
+                                      extent['id'], arg)
+                        result['extent'] = err
+                    except Exception as e:
+                        module.fail_json(msg=f"Error updating extent {name} with {arg}: {e}")
+                result['changed'] = True
+        else:
+            if module.check_mode:
+                result['msg'] = f"Would have deleted extent {name} (delete_file={delete_file}, force={force})"
+            else:
+                try:
+                    # iscsi.extent.delete signature: (id, remove, force)
+                    mw.call("iscsi.extent.delete",
+                            extent['id'], delete_file, force)
+                except Exception as e:
+                    module.fail_json(msg=f"Error deleting extent {name}: {e}")
+            result['changed'] = True
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/iscsi_extent.py
+++ b/plugins/modules/iscsi_extent.py
@@ -258,9 +258,13 @@ def main():
                 if k in _SERVER_MANAGED:
                     continue
                 current = extent.get(k)
-                # TrueNAS 25.04+ stores filesize as a string. Cast both
-                # sides to int so we don't report a spurious change every
-                # run.
+                # The middleware stores filesize as a string in the DB
+                # (api model: ``filesize: str | int``). Its read-path
+                # ``extend()`` normalizes any legacy unit-suffixed values
+                # (e.g. "10GB") to bytes before returning, so what we get
+                # back here is always either an int or a digit-only
+                # string. Cast both sides to int so a spurious diff
+                # doesn't fire on every run.
                 if k == 'filesize':
                     try:
                         current = int(current) if current is not None else current

--- a/plugins/modules/iscsi_extent.py
+++ b/plugins/modules/iscsi_extent.py
@@ -148,10 +148,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ..module_utils.middleware import MiddleWare as MW
 
 
-# Fields the middleware computes/manages and we should not diff against.
-_SERVER_MANAGED = {'naa', 'vendor', 'product_id', 'locked', 'id'}
-
-
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -255,8 +251,6 @@ def main():
             for k, v in inputs.items():
                 if v is None:
                     continue
-                if k in _SERVER_MANAGED:
-                    continue
                 current = extent.get(k)
                 # The middleware stores filesize as a string in the DB
                 # (api model: ``filesize: str | int``). Its read-path
@@ -273,6 +267,22 @@ def main():
                 if current != v:
                     arg[k] = v
 
+            # If the extent's type is changing, make sure the supporting
+            # fields for the new type are present (either in this update
+            # or already on the existing row). Leaves the actual DISK/FILE
+            # validity to the middleware but catches obvious mismatches
+            # the create path also catches.
+            if 'type' in arg:
+                new_type = arg['type']
+                if new_type == 'DISK' and \
+                   not (inputs.get('disk') or extent.get('disk')):
+                    module.fail_json(msg=f"Cannot change extent {name} to DISK: 'disk' is required")
+                if new_type == 'FILE':
+                    if not (inputs.get('path') or extent.get('path')):
+                        module.fail_json(msg=f"Cannot change extent {name} to FILE: 'path' is required")
+                    if not (inputs.get('filesize') or extent.get('filesize')):
+                        module.fail_json(msg=f"Cannot change extent {name} to FILE: 'filesize' is required")
+
             if len(arg) == 0:
                 result['changed'] = False
                 result['extent'] = extent
@@ -285,6 +295,7 @@ def main():
                                       extent['id'], arg)
                         result['extent'] = err
                     except Exception as e:
+                        result['failed_invocation'] = arg
                         module.fail_json(msg=f"Error updating extent {name} with {arg}: {e}")
                 result['changed'] = True
         else:

--- a/plugins/modules/iscsi_initiator.py
+++ b/plugins/modules/iscsi_initiator.py
@@ -30,6 +30,16 @@ options:
         labels this "Allow All Initiators").
     type: list
     elements: str
+  auth_network:
+    description:
+      - List of CIDR networks allowed to connect.
+      - This field exists on C(iscsi.initiator) only on TrueNAS CORE.
+        On TrueNAS SCALE / Community Edition the equivalent setting
+        is C(auth_networks) on the C(iscsi_target) module. Passing
+        the option on a non-CORE host produces a warning and is
+        otherwise ignored.
+    type: list
+    elements: str
   state:
     description:
       - Whether the initiator group should exist or not.
@@ -67,6 +77,7 @@ initiator:
 
 from ansible.module_utils.basic import AnsibleModule
 from ..module_utils.middleware import MiddleWare as MW
+from ..module_utils.setup import get_tn_version
 
 
 def main():
@@ -74,6 +85,7 @@ def main():
         argument_spec=dict(
             comment=dict(type='str', required=True, aliases=['name']),
             initiators=dict(type='list', elements='str'),
+            auth_network=dict(type='list', elements='str'),
             state=dict(type='str', default='present',
                        choices=['absent', 'present']),
         ),
@@ -89,7 +101,22 @@ def main():
 
     comment = module.params['comment']
     initiators = module.params['initiators']
+    auth_network = module.params['auth_network']
     state = module.params['state']
+
+    try:
+        tn_version = get_tn_version()
+    except Exception as e:
+        module.fail_json(msg=f"Error getting TrueNAS version: {e}")
+
+    is_core = tn_version['type'] == 'CORE'
+
+    if auth_network is not None and not is_core:
+        module.warn("auth_network is only supported on TrueNAS CORE; "
+                    "use the iscsi_target module's auth_networks option "
+                    "on TrueNAS SCALE / Community Edition. The supplied "
+                    "value is ignored.")
+        auth_network = None
 
     try:
         rows = mw.call("iscsi.initiator.query",
@@ -103,6 +130,8 @@ def main():
             arg = {"comment": comment}
             if initiators is not None:
                 arg['initiators'] = initiators
+            if auth_network is not None:
+                arg['auth_network'] = auth_network
 
             if module.check_mode:
                 result['msg'] = f"Would have created initiator group {comment} with {arg}"
@@ -123,6 +152,10 @@ def main():
             if initiators is not None:
                 if set(initiators) != set(ig.get('initiators') or []):
                     arg['initiators'] = initiators
+
+            if auth_network is not None:
+                if set(auth_network) != set(ig.get('auth_network') or []):
+                    arg['auth_network'] = auth_network
 
             if len(arg) == 0:
                 result['changed'] = False

--- a/plugins/modules/iscsi_initiator.py
+++ b/plugins/modules/iscsi_initiator.py
@@ -1,0 +1,155 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+__metaclass__ = type
+
+# Manage iSCSI initiator (host) groups.
+
+DOCUMENTATION = '''
+---
+module: iscsi_initiator
+short_description: Manage iSCSI initiator groups
+description:
+  - Create, modify, and delete iSCSI initiator (host) groups.
+  - An initiator group lists IQNs allowed to access targets that
+    reference it. An empty C(initiators) list grants access to ALL
+    initiators.
+options:
+  comment:
+    description:
+      - Free-form description for the initiator group. Used as the
+        identifier because the TrueNAS API does not assign initiator
+        groups a stable name.
+      - Required.
+    type: str
+    required: true
+    aliases: [ name ]
+  initiators:
+    description:
+      - List of allowed initiator IQNs.
+      - An empty list grants access to ALL initiators (the TrueNAS UI
+        labels this "Allow All Initiators").
+    type: list
+    elements: str
+  state:
+    description:
+      - Whether the initiator group should exist or not.
+    type: str
+    choices: [ absent, present ]
+    default: present
+version_added: 1.15.0
+'''
+
+EXAMPLES = '''
+- name: Allow two specific initiators
+  arensb.truenas.iscsi_initiator:
+    comment: lab-hosts
+    initiators:
+      - iqn.1993-08.org.debian:01:abc
+      - iqn.1993-08.org.debian:01:def
+
+- name: Allow all initiators
+  arensb.truenas.iscsi_initiator:
+    comment: anyone
+    initiators: []
+
+- name: Remove initiator group
+  arensb.truenas.iscsi_initiator:
+    comment: lab-hosts
+    state: absent
+'''
+
+RETURN = '''
+initiator:
+  description:
+    - A dict describing the initiator group after the operation.
+  type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ..module_utils.middleware import MiddleWare as MW
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            comment=dict(type='str', required=True, aliases=['name']),
+            initiators=dict(type='list', elements='str'),
+            state=dict(type='str', default='present',
+                       choices=['absent', 'present']),
+        ),
+        supports_check_mode=True,
+    )
+
+    result = dict(
+        changed=False,
+        msg=''
+    )
+
+    mw = MW.client()
+
+    comment = module.params['comment']
+    initiators = module.params['initiators']
+    state = module.params['state']
+
+    try:
+        rows = mw.call("iscsi.initiator.query",
+                       [["comment", "=", comment]])
+        ig = rows[0] if rows else None
+    except Exception as e:
+        module.fail_json(msg=f"Error looking up initiator group {comment}: {e}")
+
+    if ig is None:
+        if state == 'present':
+            arg = {"comment": comment}
+            if initiators is not None:
+                arg['initiators'] = initiators
+
+            if module.check_mode:
+                result['msg'] = f"Would have created initiator group {comment} with {arg}"
+            else:
+                try:
+                    err = mw.call("iscsi.initiator.create", arg)
+                    result['initiator'] = err
+                except Exception as e:
+                    result['failed_invocation'] = arg
+                    module.fail_json(msg=f"Error creating initiator group {comment}: {e}")
+            result['changed'] = True
+        else:
+            result['changed'] = False
+    else:
+        if state == 'present':
+            arg = {}
+
+            if initiators is not None:
+                if set(initiators) != set(ig.get('initiators') or []):
+                    arg['initiators'] = initiators
+
+            if len(arg) == 0:
+                result['changed'] = False
+                result['initiator'] = ig
+            else:
+                if module.check_mode:
+                    result['msg'] = f"Would have updated initiator group {comment}: {arg}"
+                else:
+                    try:
+                        err = mw.call("iscsi.initiator.update",
+                                      ig['id'], arg)
+                        result['initiator'] = err
+                    except Exception as e:
+                        module.fail_json(msg=f"Error updating initiator group {comment} with {arg}: {e}")
+                result['changed'] = True
+        else:
+            if module.check_mode:
+                result['msg'] = f"Would have deleted initiator group {comment}"
+            else:
+                try:
+                    mw.call("iscsi.initiator.delete", ig['id'])
+                except Exception as e:
+                    module.fail_json(msg=f"Error deleting initiator group {comment}: {e}")
+            result['changed'] = True
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/iscsi_initiator.py
+++ b/plugins/modules/iscsi_initiator.py
@@ -169,6 +169,7 @@ def main():
                                       ig['id'], arg)
                         result['initiator'] = err
                     except Exception as e:
+                        result['failed_invocation'] = arg
                         module.fail_json(msg=f"Error updating initiator group {comment} with {arg}: {e}")
                 result['changed'] = True
         else:

--- a/plugins/modules/iscsi_portal.py
+++ b/plugins/modules/iscsi_portal.py
@@ -28,15 +28,29 @@ options:
       - Required when creating a portal.
     type: list
     elements: str
+  port:
+    description:
+      - TCP port the portal listens on. Only used on TrueNAS CORE,
+        where the listen port is configured per-portal. Ignored on
+        TrueNAS SCALE / Community Edition (use the C(listen_port)
+        option of the C(iscsi) module there). Default is C(3260).
+    type: int
+    default: 3260
   discovery_authmethod:
     description:
       - Authentication method to require for discovery-phase logins.
+      - Removed from C(iscsi.portal) in TrueNAS SCALE 25.04 and replaced
+        by C(discovery_auth) on C(iscsi_auth). On 25.04+ this option is
+        ignored with a warning.
     type: str
     choices: [ NONE, CHAP, CHAP_MUTUAL ]
   discovery_authgroup:
     description:
       - C(tag) of an C(iscsi_auth) entry to use for discovery
-        authentication. Set to C(0) or null to disable.
+        authentication. Use null (omit) to disable; the TrueNAS API
+        does not treat C(0) as "disabled".
+      - Removed from C(iscsi.portal) in TrueNAS SCALE 25.04. On 25.04+
+        this option is ignored with a warning.
     type: int
   state:
     description:
@@ -54,7 +68,14 @@ EXAMPLES = '''
     listen:
       - 0.0.0.0
 
-- name: Portal that requires mutual CHAP at discovery
+- name: Portal on a non-default port (TrueNAS CORE only)
+  arensb.truenas.iscsi_portal:
+    comment: alt-port
+    listen:
+      - 10.0.0.10
+    port: 3261
+
+- name: Portal that requires mutual CHAP at discovery (pre-25.04)
   arensb.truenas.iscsi_portal:
     comment: secured
     listen:
@@ -76,19 +97,43 @@ portal:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
+from packaging import version
 from ..module_utils.middleware import MiddleWare as MW
+from ..module_utils.setup import get_tn_version
 
 
-def _normalize_listen(items):
-    """Convert middleware listen entries (list of dicts with 'ip') to a
-    plain list of IP strings, suitable for set comparison.
+# TrueNAS SCALE 25.04 (Fangtooth) removed the discovery_auth* fields
+# from iscsi.portal; they moved to iscsi.auth.discovery_auth.
+TC_25_04 = version.parse("25.04")
+
+
+def _is_scale_or_ce(tnv):
+    return tnv['type'] in {"SCALE", "COMMUNITY_EDITION", "ENTERPRISE"}
+
+
+def _supports_discovery_auth_on_portal(tnv):
+    if tnv['type'] == 'CORE':
+        return True
+    if _is_scale_or_ce(tnv) and tnv['version'] < TC_25_04:
+        return True
+    return False
+
+
+def _normalize_listen(items, want_port=False):
+    """Reduce middleware listen entries to a comparable form.
+
+    On modern TrueNAS the items are dicts with only ``ip``. On TrueNAS
+    CORE they are dicts with ``ip`` and ``port``; ``want_port`` says
+    whether the caller wants a tuple including the port (for CORE diff).
     """
     out = []
     for item in items or []:
         if isinstance(item, dict):
-            out.append(item.get('ip'))
+            ip = item.get('ip')
+            port = item.get('port')
+            out.append((ip, port) if want_port else ip)
         else:
-            out.append(item)
+            out.append((item, None) if want_port else item)
     return out
 
 
@@ -97,6 +142,7 @@ def main():
         argument_spec=dict(
             comment=dict(type='str', required=True, aliases=['name']),
             listen=dict(type='list', elements='str'),
+            port=dict(type='int', default=3260),
             discovery_authmethod=dict(type='str',
                                       choices=['NONE', 'CHAP', 'CHAP_MUTUAL']),
             discovery_authgroup=dict(type='int'),
@@ -115,9 +161,37 @@ def main():
 
     comment = module.params['comment']
     listen = module.params['listen']
+    port = module.params['port']
     discovery_authmethod = module.params['discovery_authmethod']
     discovery_authgroup = module.params['discovery_authgroup']
     state = module.params['state']
+
+    try:
+        tn_version = get_tn_version()
+    except Exception as e:
+        module.fail_json(msg=f"Error getting TrueNAS version: {e}")
+
+    is_core = tn_version['type'] == 'CORE'
+    discovery_on_portal = _supports_discovery_auth_on_portal(tn_version)
+
+    if not is_core and module.params.get('port') != 3260:
+        module.warn("'port' is ignored on TrueNAS SCALE / Community "
+                    "Edition; configure the listen port via the "
+                    "'iscsi' module's listen_port option.")
+
+    if (discovery_authmethod is not None or discovery_authgroup is not None) \
+       and not discovery_on_portal:
+        module.warn("discovery_authmethod/discovery_authgroup are not "
+                    "available on iscsi.portal in TrueNAS SCALE 25.04+; "
+                    "use the iscsi_auth module's discovery_auth option "
+                    "instead. The supplied values are ignored.")
+        discovery_authmethod = None
+        discovery_authgroup = None
+
+    def build_listen(ip_list):
+        if is_core:
+            return [{"ip": ip, "port": port} for ip in ip_list]
+        return [{"ip": ip} for ip in ip_list]
 
     try:
         rows = mw.call("iscsi.portal.query",
@@ -133,7 +207,7 @@ def main():
 
             arg = {
                 "comment": comment,
-                "listen": [{"ip": ip} for ip in listen],
+                "listen": build_listen(listen),
             }
             if discovery_authmethod is not None:
                 arg['discovery_authmethod'] = discovery_authmethod
@@ -157,9 +231,15 @@ def main():
             arg = {}
 
             if listen is not None:
-                current = set(_normalize_listen(portal.get('listen')))
-                if set(listen) != current:
-                    arg['listen'] = [{"ip": ip} for ip in listen]
+                if is_core:
+                    current = set(_normalize_listen(portal.get('listen'),
+                                                    want_port=True))
+                    desired = {(ip, port) for ip in listen}
+                else:
+                    current = set(_normalize_listen(portal.get('listen')))
+                    desired = set(listen)
+                if desired != current:
+                    arg['listen'] = build_listen(listen)
 
             if discovery_authmethod is not None and \
                portal.get('discovery_authmethod') != discovery_authmethod:

--- a/plugins/modules/iscsi_portal.py
+++ b/plugins/modules/iscsi_portal.py
@@ -1,0 +1,200 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+__metaclass__ = type
+
+# Manage iSCSI portals.
+
+DOCUMENTATION = '''
+---
+module: iscsi_portal
+short_description: Manage iSCSI portals
+description:
+  - Create, modify, and delete iSCSI portals.
+  - A portal binds the iSCSI target service to one or more IP addresses
+    on the server, and may optionally require discovery-time CHAP.
+options:
+  comment:
+    description:
+      - Free-form description for the portal. Used as the identifier
+        because the TrueNAS API does not assign portals a stable name.
+      - Required.
+    type: str
+    required: true
+    aliases: [ name ]
+  listen:
+    description:
+      - List of IP addresses the portal listens on. C(0.0.0.0) means
+        "listen on all IPv4 addresses".
+      - Required when creating a portal.
+    type: list
+    elements: str
+  discovery_authmethod:
+    description:
+      - Authentication method to require for discovery-phase logins.
+    type: str
+    choices: [ NONE, CHAP, CHAP_MUTUAL ]
+  discovery_authgroup:
+    description:
+      - C(tag) of an C(iscsi_auth) entry to use for discovery
+        authentication. Set to C(0) or null to disable.
+    type: int
+  state:
+    description:
+      - Whether the portal should exist or not.
+    type: str
+    choices: [ absent, present ]
+    default: present
+version_added: 1.15.0
+'''
+
+EXAMPLES = '''
+- name: Listen-on-all portal
+  arensb.truenas.iscsi_portal:
+    comment: default
+    listen:
+      - 0.0.0.0
+
+- name: Portal that requires mutual CHAP at discovery
+  arensb.truenas.iscsi_portal:
+    comment: secured
+    listen:
+      - 10.0.0.10
+    discovery_authmethod: CHAP_MUTUAL
+    discovery_authgroup: 1
+
+- name: Remove portal
+  arensb.truenas.iscsi_portal:
+    comment: old-portal
+    state: absent
+'''
+
+RETURN = '''
+portal:
+  description:
+    - A dict describing the portal after the operation.
+  type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ..module_utils.middleware import MiddleWare as MW
+
+
+def _normalize_listen(items):
+    """Convert middleware listen entries (list of dicts with 'ip') to a
+    plain list of IP strings, suitable for set comparison.
+    """
+    out = []
+    for item in items or []:
+        if isinstance(item, dict):
+            out.append(item.get('ip'))
+        else:
+            out.append(item)
+    return out
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            comment=dict(type='str', required=True, aliases=['name']),
+            listen=dict(type='list', elements='str'),
+            discovery_authmethod=dict(type='str',
+                                      choices=['NONE', 'CHAP', 'CHAP_MUTUAL']),
+            discovery_authgroup=dict(type='int'),
+            state=dict(type='str', default='present',
+                       choices=['absent', 'present']),
+        ),
+        supports_check_mode=True,
+    )
+
+    result = dict(
+        changed=False,
+        msg=''
+    )
+
+    mw = MW.client()
+
+    comment = module.params['comment']
+    listen = module.params['listen']
+    discovery_authmethod = module.params['discovery_authmethod']
+    discovery_authgroup = module.params['discovery_authgroup']
+    state = module.params['state']
+
+    try:
+        rows = mw.call("iscsi.portal.query",
+                       [["comment", "=", comment]])
+        portal = rows[0] if rows else None
+    except Exception as e:
+        module.fail_json(msg=f"Error looking up portal {comment}: {e}")
+
+    if portal is None:
+        if state == 'present':
+            if not listen:
+                module.fail_json(msg=f"Cannot create portal {comment}: 'listen' is required")
+
+            arg = {
+                "comment": comment,
+                "listen": [{"ip": ip} for ip in listen],
+            }
+            if discovery_authmethod is not None:
+                arg['discovery_authmethod'] = discovery_authmethod
+            if discovery_authgroup is not None:
+                arg['discovery_authgroup'] = discovery_authgroup
+
+            if module.check_mode:
+                result['msg'] = f"Would have created portal {comment} with {arg}"
+            else:
+                try:
+                    err = mw.call("iscsi.portal.create", arg)
+                    result['portal'] = err
+                except Exception as e:
+                    result['failed_invocation'] = arg
+                    module.fail_json(msg=f"Error creating portal {comment}: {e}")
+            result['changed'] = True
+        else:
+            result['changed'] = False
+    else:
+        if state == 'present':
+            arg = {}
+
+            if listen is not None:
+                current = set(_normalize_listen(portal.get('listen')))
+                if set(listen) != current:
+                    arg['listen'] = [{"ip": ip} for ip in listen]
+
+            if discovery_authmethod is not None and \
+               portal.get('discovery_authmethod') != discovery_authmethod:
+                arg['discovery_authmethod'] = discovery_authmethod
+
+            if discovery_authgroup is not None and \
+               portal.get('discovery_authgroup') != discovery_authgroup:
+                arg['discovery_authgroup'] = discovery_authgroup
+
+            if len(arg) == 0:
+                result['changed'] = False
+                result['portal'] = portal
+            else:
+                if module.check_mode:
+                    result['msg'] = f"Would have updated portal {comment}: {arg}"
+                else:
+                    try:
+                        err = mw.call("iscsi.portal.update",
+                                      portal['id'], arg)
+                        result['portal'] = err
+                    except Exception as e:
+                        module.fail_json(msg=f"Error updating portal {comment} with {arg}: {e}")
+                result['changed'] = True
+        else:
+            if module.check_mode:
+                result['msg'] = f"Would have deleted portal {comment}"
+            else:
+                try:
+                    mw.call("iscsi.portal.delete", portal['id'])
+                except Exception as e:
+                    module.fail_json(msg=f"Error deleting portal {comment}: {e}")
+            result['changed'] = True
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/iscsi_portal.py
+++ b/plugins/modules/iscsi_portal.py
@@ -33,9 +33,10 @@ options:
       - TCP port the portal listens on. Only used on TrueNAS CORE,
         where the listen port is configured per-portal. Ignored on
         TrueNAS SCALE / Community Edition (use the C(listen_port)
-        option of the C(iscsi) module there). Default is C(3260).
+        option of the C(iscsi) module there).
+      - Omit to leave the existing port alone on update, or to use
+        C(3260) on create.
     type: int
-    default: 3260
   discovery_authmethod:
     description:
       - Authentication method to require for discovery-phase logins.
@@ -108,7 +109,7 @@ TC_25_04 = version.parse("25.04")
 
 
 def _is_scale_or_ce(tnv):
-    return tnv['type'] in {"SCALE", "COMMUNITY_EDITION", "ENTERPRISE"}
+    return tnv['type'] in {"SCALE", "COMMUNITY_EDITION"}
 
 
 def _supports_discovery_auth_on_portal(tnv):
@@ -142,7 +143,7 @@ def main():
         argument_spec=dict(
             comment=dict(type='str', required=True, aliases=['name']),
             listen=dict(type='list', elements='str'),
-            port=dict(type='int', default=3260),
+            port=dict(type='int'),
             discovery_authmethod=dict(type='str',
                                       choices=['NONE', 'CHAP', 'CHAP_MUTUAL']),
             discovery_authgroup=dict(type='int'),
@@ -174,7 +175,7 @@ def main():
     is_core = tn_version['type'] == 'CORE'
     discovery_on_portal = _supports_discovery_auth_on_portal(tn_version)
 
-    if not is_core and module.params.get('port') != 3260:
+    if port is not None and not is_core:
         module.warn("'port' is ignored on TrueNAS SCALE / Community "
                     "Edition; configure the listen port via the "
                     "'iscsi' module's listen_port option.")
@@ -188,10 +189,31 @@ def main():
         discovery_authmethod = None
         discovery_authgroup = None
 
+    def _existing_port_map():
+        """Return ip->port for the IPs already on this portal."""
+        if not is_core:
+            return {}
+        return {ip: prt
+                for ip, prt in _normalize_listen(
+                    (portal or {}).get('listen'), want_port=True)
+                if prt is not None}
+
     def build_listen(ip_list):
-        if is_core:
-            return [{"ip": ip, "port": port} for ip in ip_list]
-        return [{"ip": ip} for ip in ip_list]
+        if not is_core:
+            return [{"ip": ip} for ip in ip_list]
+        existing = _existing_port_map()
+        out = []
+        for ip in ip_list:
+            # Explicit port wins; otherwise reuse the existing port for
+            # this IP if known; otherwise fall back to 3260 on create.
+            if port is not None:
+                prt = port
+            elif ip in existing:
+                prt = existing[ip]
+            else:
+                prt = 3260
+            out.append({"ip": ip, "port": prt})
+        return out
 
     try:
         rows = mw.call("iscsi.portal.query",
@@ -234,7 +256,8 @@ def main():
                 if is_core:
                     current = set(_normalize_listen(portal.get('listen'),
                                                     want_port=True))
-                    desired = {(ip, port) for ip in listen}
+                    desired = {(item['ip'], item['port'])
+                               for item in build_listen(listen)}
                 else:
                     current = set(_normalize_listen(portal.get('listen')))
                     desired = set(listen)
@@ -261,6 +284,7 @@ def main():
                                       portal['id'], arg)
                         result['portal'] = err
                     except Exception as e:
+                        result['failed_invocation'] = arg
                         module.fail_json(msg=f"Error updating portal {comment} with {arg}: {e}")
                 result['changed'] = True
         else:

--- a/plugins/modules/iscsi_target.py
+++ b/plugins/modules/iscsi_target.py
@@ -1,0 +1,253 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+__metaclass__ = type
+
+# Manage iSCSI targets.
+
+DOCUMENTATION = '''
+---
+module: iscsi_target
+short_description: Manage iSCSI targets
+description:
+  - Create, modify, and delete iSCSI targets.
+  - A target is the IQN that initiators connect to. The target name
+    is appended to the iSCSI service C(basename) to form the full IQN.
+  - Each target has a list of access C(groups), where each group binds
+    a portal, an initiator group, and an authentication setting.
+options:
+  name:
+    description:
+      - Name of the target. Combined with the service basename to form
+        the full IQN.
+    type: str
+    required: true
+  alias:
+    description:
+      - Free-form alias.
+    type: str
+  mode:
+    description:
+      - Transport mode. C(ISCSI) is the only meaningful value on
+        non-FC hardware.
+    type: str
+    choices: [ ISCSI, FC, BOTH ]
+  groups:
+    description:
+      - List of access groups bound to this target.
+    type: list
+    elements: dict
+    suboptions:
+      portal:
+        description:
+          - C(id) of an C(iscsi_portal) entry.
+        type: int
+        required: true
+      initiator:
+        description:
+          - C(id) of an C(iscsi_initiator) group, or null to allow all.
+        type: int
+      authmethod:
+        description:
+          - Authentication method for this group.
+        type: str
+        choices: [ NONE, CHAP, CHAP_MUTUAL ]
+        default: NONE
+      auth:
+        description:
+          - C(tag) of an C(iscsi_auth) entry. Required if
+            C(authmethod) is not C(NONE).
+        type: int
+  auth_networks:
+    description:
+      - List of CIDR networks allowed to connect to this target.
+        Empty list means "any network".
+    type: list
+    elements: str
+  force:
+    description:
+      - When deleting, bypass the active-session safety check.
+    type: bool
+    default: false
+  state:
+    description:
+      - Whether the target should exist or not.
+    type: str
+    choices: [ absent, present ]
+    default: present
+version_added: 1.15.0
+'''
+
+EXAMPLES = '''
+- name: Simple target with one portal, no auth, all initiators
+  arensb.truenas.iscsi_target:
+    name: tgt0
+    groups:
+      - portal: 1
+        initiator: 1
+        authmethod: NONE
+
+- name: Target with CHAP and a network restriction
+  arensb.truenas.iscsi_target:
+    name: tgt-secure
+    alias: "secure target"
+    groups:
+      - portal: 1
+        initiator: 2
+        authmethod: CHAP
+        auth: 1
+    auth_networks:
+      - 10.0.0.0/24
+
+- name: Remove target (force, ignoring active sessions)
+  arensb.truenas.iscsi_target:
+    name: tgt-old
+    state: absent
+    force: true
+'''
+
+RETURN = '''
+target:
+  description:
+    - A dict describing the target after the operation.
+  type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ..module_utils.middleware import MiddleWare as MW
+
+
+def _normalize_group(g):
+    """Reduce a group dict to its diffable fields with stable defaults
+    so user-supplied and server-returned groups can be compared."""
+    return {
+        'portal': g.get('portal'),
+        'initiator': g.get('initiator'),
+        'authmethod': g.get('authmethod') or 'NONE',
+        'auth': g.get('auth'),
+    }
+
+
+def _groups_equal(a, b):
+    if a is None or b is None:
+        return a == b
+    return [_normalize_group(g) for g in a] == [_normalize_group(g) for g in b]
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(type='str', required=True),
+            alias=dict(type='str'),
+            mode=dict(type='str', choices=['ISCSI', 'FC', 'BOTH']),
+            groups=dict(
+                type='list', elements='dict',
+                options=dict(
+                    portal=dict(type='int', required=True),
+                    initiator=dict(type='int'),
+                    authmethod=dict(type='str',
+                                    choices=['NONE', 'CHAP', 'CHAP_MUTUAL'],
+                                    default='NONE'),
+                    auth=dict(type='int'),
+                ),
+            ),
+            auth_networks=dict(type='list', elements='str'),
+            force=dict(type='bool', default=False),
+            state=dict(type='str', default='present',
+                       choices=['absent', 'present']),
+        ),
+        supports_check_mode=True,
+    )
+
+    result = dict(
+        changed=False,
+        msg=''
+    )
+
+    mw = MW.client()
+
+    name = module.params['name']
+    alias = module.params['alias']
+    mode = module.params['mode']
+    groups = module.params['groups']
+    auth_networks = module.params['auth_networks']
+    force = module.params['force']
+    state = module.params['state']
+
+    try:
+        rows = mw.call("iscsi.target.query",
+                       [["name", "=", name]])
+        target = rows[0] if rows else None
+    except Exception as e:
+        module.fail_json(msg=f"Error looking up target {name}: {e}")
+
+    if target is None:
+        if state == 'present':
+            arg = {"name": name}
+            if alias is not None:
+                arg['alias'] = alias
+            if mode is not None:
+                arg['mode'] = mode
+            if groups is not None:
+                arg['groups'] = [_normalize_group(g) for g in groups]
+            if auth_networks is not None:
+                arg['auth_networks'] = auth_networks
+
+            if module.check_mode:
+                result['msg'] = f"Would have created target {name} with {arg}"
+            else:
+                try:
+                    err = mw.call("iscsi.target.create", arg)
+                    result['target'] = err
+                except Exception as e:
+                    result['failed_invocation'] = arg
+                    module.fail_json(msg=f"Error creating target {name}: {e}")
+            result['changed'] = True
+        else:
+            result['changed'] = False
+    else:
+        if state == 'present':
+            arg = {}
+
+            if alias is not None and target.get('alias') != alias:
+                arg['alias'] = alias
+
+            if mode is not None and target.get('mode') != mode:
+                arg['mode'] = mode
+
+            if groups is not None and \
+               not _groups_equal(groups, target.get('groups')):
+                arg['groups'] = [_normalize_group(g) for g in groups]
+
+            if auth_networks is not None and \
+               set(auth_networks) != set(target.get('auth_networks') or []):
+                arg['auth_networks'] = auth_networks
+
+            if len(arg) == 0:
+                result['changed'] = False
+                result['target'] = target
+            else:
+                if module.check_mode:
+                    result['msg'] = f"Would have updated target {name}: {arg}"
+                else:
+                    try:
+                        err = mw.call("iscsi.target.update",
+                                      target['id'], arg)
+                        result['target'] = err
+                    except Exception as e:
+                        module.fail_json(msg=f"Error updating target {name} with {arg}: {e}")
+                result['changed'] = True
+        else:
+            if module.check_mode:
+                result['msg'] = f"Would have deleted target {name} (force={force})"
+            else:
+                try:
+                    mw.call("iscsi.target.delete", target['id'], force)
+                except Exception as e:
+                    module.fail_json(msg=f"Error deleting target {name}: {e}")
+            result['changed'] = True
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/iscsi_target.py
+++ b/plugins/modules/iscsi_target.py
@@ -61,6 +61,11 @@ options:
     description:
       - List of CIDR networks allowed to connect to this target.
         Empty list means "any network".
+      - This field is on C(iscsi.target) only on TrueNAS SCALE /
+        Community Edition. On TrueNAS CORE the equivalent setting is
+        C(auth_network) on the C(iscsi_initiator) module. Passing the
+        option on a CORE host produces a warning and is otherwise
+        ignored.
     type: list
     elements: str
   force:
@@ -114,6 +119,7 @@ target:
 
 from ansible.module_utils.basic import AnsibleModule
 from ..module_utils.middleware import MiddleWare as MW
+from ..module_utils.setup import get_tn_version
 
 
 def _normalize_group(g):
@@ -183,6 +189,18 @@ def main():
     auth_networks = module.params['auth_networks']
     force = module.params['force']
     state = module.params['state']
+
+    try:
+        tn_version = get_tn_version()
+    except Exception as e:
+        module.fail_json(msg=f"Error getting TrueNAS version: {e}")
+
+    if auth_networks is not None and tn_version['type'] == 'CORE':
+        module.warn("auth_networks is not available on iscsi.target on "
+                    "TrueNAS CORE; use the iscsi_initiator module's "
+                    "auth_network option instead. The supplied value is "
+                    "ignored.")
+        auth_networks = None
 
     try:
         rows = mw.call("iscsi.target.query",

--- a/plugins/modules/iscsi_target.py
+++ b/plugins/modules/iscsi_target.py
@@ -127,10 +127,21 @@ def _normalize_group(g):
     }
 
 
+def _group_sort_key(g):
+    # Coerce None to a stable tuple-comparable sentinel.
+    return tuple((-1 if g[k] is None else g[k])
+                 for k in ('portal', 'initiator', 'authmethod', 'auth'))
+
+
 def _groups_equal(a, b):
+    # Server stores groups as a set; compare unordered to avoid
+    # spurious diffs when the user supplies them in a different order
+    # than the API returns.
     if a is None or b is None:
         return a == b
-    return [_normalize_group(g) for g in a] == [_normalize_group(g) for g in b]
+    na = sorted([_normalize_group(g) for g in a], key=_group_sort_key)
+    nb = sorted([_normalize_group(g) for g in b], key=_group_sort_key)
+    return na == nb
 
 
 def main():

--- a/plugins/modules/iscsi_target.py
+++ b/plugins/modules/iscsi_target.py
@@ -263,6 +263,7 @@ def main():
                                       target['id'], arg)
                         result['target'] = err
                     except Exception as e:
+                        result['failed_invocation'] = arg
                         module.fail_json(msg=f"Error updating target {name} with {arg}: {e}")
                 result['changed'] = True
         else:

--- a/plugins/modules/iscsi_targetextent.py
+++ b/plugins/modules/iscsi_targetextent.py
@@ -30,6 +30,11 @@ options:
       - LUN number to advertise. Auto-assigned (lowest free) if unset
         on create.
     type: int
+  force:
+    description:
+      - When deleting, bypass the active-session safety check.
+    type: bool
+    default: false
   state:
     description:
       - Whether the association should exist or not.
@@ -75,6 +80,7 @@ def main():
             target=dict(type='int', required=True),
             extent=dict(type='int', required=True),
             lunid=dict(type='int'),
+            force=dict(type='bool', default=False),
             state=dict(type='str', default='present',
                        choices=['absent', 'present']),
         ),
@@ -91,6 +97,7 @@ def main():
     target = module.params['target']
     extent = module.params['extent']
     lunid = module.params['lunid']
+    force = module.params['force']
     state = module.params['state']
 
     label = f"target={target}, extent={extent}"
@@ -142,10 +149,10 @@ def main():
                 result['changed'] = True
         else:
             if module.check_mode:
-                result['msg'] = f"Would have deleted targetextent ({label})"
+                result['msg'] = f"Would have deleted targetextent ({label}, force={force})"
             else:
                 try:
-                    mw.call("iscsi.targetextent.delete", row['id'])
+                    mw.call("iscsi.targetextent.delete", row['id'], force)
                 except Exception as e:
                     module.fail_json(msg=f"Error deleting targetextent ({label}): {e}")
             result['changed'] = True

--- a/plugins/modules/iscsi_targetextent.py
+++ b/plugins/modules/iscsi_targetextent.py
@@ -1,0 +1,157 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+__metaclass__ = type
+
+# Manage iSCSI target/extent associations (LUNs).
+
+DOCUMENTATION = '''
+---
+module: iscsi_targetextent
+short_description: Manage iSCSI target/extent associations (LUNs)
+description:
+  - Create, modify, and delete LUN bindings between an iSCSI target and
+    an extent.
+  - Identified by the C((target, extent)) pair. The C(lunid) is the
+    LUN number presented to initiators; if not specified on create,
+    the middleware picks the lowest free value.
+options:
+  target:
+    description:
+      - C(id) of an C(iscsi_target) row.
+    type: int
+    required: true
+  extent:
+    description:
+      - C(id) of an C(iscsi_extent) row.
+    type: int
+    required: true
+  lunid:
+    description:
+      - LUN number to advertise. Auto-assigned (lowest free) if unset
+        on create.
+    type: int
+  state:
+    description:
+      - Whether the association should exist or not.
+    type: str
+    choices: [ absent, present ]
+    default: present
+version_added: 1.15.0
+'''
+
+EXAMPLES = '''
+- name: Bind extent 5 to target 2 as LUN 0
+  arensb.truenas.iscsi_targetextent:
+    target: 2
+    extent: 5
+    lunid: 0
+
+- name: Auto-assign LUN
+  arensb.truenas.iscsi_targetextent:
+    target: 2
+    extent: 6
+
+- name: Remove association
+  arensb.truenas.iscsi_targetextent:
+    target: 2
+    extent: 5
+    state: absent
+'''
+
+RETURN = '''
+targetextent:
+  description:
+    - A dict describing the target/extent association after the operation.
+  type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ..module_utils.middleware import MiddleWare as MW
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            target=dict(type='int', required=True),
+            extent=dict(type='int', required=True),
+            lunid=dict(type='int'),
+            state=dict(type='str', default='present',
+                       choices=['absent', 'present']),
+        ),
+        supports_check_mode=True,
+    )
+
+    result = dict(
+        changed=False,
+        msg=''
+    )
+
+    mw = MW.client()
+
+    target = module.params['target']
+    extent = module.params['extent']
+    lunid = module.params['lunid']
+    state = module.params['state']
+
+    label = f"target={target}, extent={extent}"
+
+    try:
+        rows = mw.call("iscsi.targetextent.query",
+                       [["target", "=", target], ["extent", "=", extent]])
+        row = rows[0] if rows else None
+    except Exception as e:
+        module.fail_json(msg=f"Error looking up targetextent ({label}): {e}")
+
+    if row is None:
+        if state == 'present':
+            arg = {"target": target, "extent": extent}
+            if lunid is not None:
+                arg['lunid'] = lunid
+
+            if module.check_mode:
+                result['msg'] = f"Would have created targetextent ({label}) with {arg}"
+            else:
+                try:
+                    err = mw.call("iscsi.targetextent.create", arg)
+                    result['targetextent'] = err
+                except Exception as e:
+                    result['failed_invocation'] = arg
+                    module.fail_json(msg=f"Error creating targetextent ({label}): {e}")
+            result['changed'] = True
+        else:
+            result['changed'] = False
+    else:
+        if state == 'present':
+            arg = {}
+            if lunid is not None and row.get('lunid') != lunid:
+                arg['lunid'] = lunid
+
+            if len(arg) == 0:
+                result['changed'] = False
+                result['targetextent'] = row
+            else:
+                if module.check_mode:
+                    result['msg'] = f"Would have updated targetextent ({label}): {arg}"
+                else:
+                    try:
+                        err = mw.call("iscsi.targetextent.update",
+                                      row['id'], arg)
+                        result['targetextent'] = err
+                    except Exception as e:
+                        module.fail_json(msg=f"Error updating targetextent ({label}) with {arg}: {e}")
+                result['changed'] = True
+        else:
+            if module.check_mode:
+                result['msg'] = f"Would have deleted targetextent ({label})"
+            else:
+                try:
+                    mw.call("iscsi.targetextent.delete", row['id'])
+                except Exception as e:
+                    module.fail_json(msg=f"Error deleting targetextent ({label}): {e}")
+            result['changed'] = True
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/iscsi_targetextent.py
+++ b/plugins/modules/iscsi_targetextent.py
@@ -145,6 +145,7 @@ def main():
                                       row['id'], arg)
                         result['targetextent'] = err
                     except Exception as e:
+                        result['failed_invocation'] = arg
                         module.fail_json(msg=f"Error updating targetextent ({label}) with {arg}: {e}")
                 result['changed'] = True
         else:


### PR DESCRIPTION
This PR adds support for managing iSCSI sharing on TrueNAS, split across seven new modules that mirror the middleware namespaces:

- `iscsi`: global iSCSI service settings (basename, isns_servers, listen_port, pool_avail_threshold, alua)
- `iscsi_portal`: portals
- `iscsi_initiator`: initiator (host) groups
- `iscsi_auth`: CHAP entries (grouped by tag)
- `iscsi_extent`: LUN backing stores (DISK zvols and FILE images)
- `iscsi_target`: targets, with portal/initiator/auth groups and CIDR ACLs
- `iscsi_targetextent`: target <--> extent associations (LUN bindings)

Service start/stop continues to be handled by the existing `service` module with `name: iscsitarget`, so no new module is added for that.

New modules follow the conventions of the existing codebase. I addded a changelog fragment under `changelogs/fragments/`.

This implementation uses branching based on the `setup.get_tn_version()` and `packaging.version`, to be compatible with TrueNAS `CORE 13.0`, TrueNAS SCALE `22.12`, `23.10`, `24.10`, `25.04`:

- `iscsi.global` has no `listen_port` on CORE, so the option is warned-and-skipped there. CORE configures the listen port per-portal instead.
- Portal `listen` items are `{ip, port}` on CORE and `{ip}` only on SCALE 22.12+; `iscsi_portal` has a `port` option that is consumed only on CORE. When omitted on update, the existing per-IP port is preserved (avoids a silent default-flip).
- `auth_network` lives on `iscsi.initiator` on CORE and on `iscsi.target.auth_networks` on SCALE (each module exposes the option for its own platform and warns/drops it when set on the other)
- The portal-level `discovery_authmethod`/`discovery_authgroup` fields were removed in SCALE 25.04 in favour of `discovery_auth` on `iscsi.auth`. The new option is exposed on `iscsi_auth` (≥ 25.04 only).

A few smaller details to watch out for:
- `iscsi_target` sorts groups before diffing because the middleware stores them as a set, so input order vs. query order might otherwise report false-positive changes.
- `iscsi_extent` casts `filesize` to int before diffing because the 25.04 entry types it as `str | int`.
- `iscsi_targetextent` exposes a `force` flag on delete (parity with the other modules).

Would love to see some testing on various TrueNAS versions!